### PR TITLE
Fix the documentation publishing on plugin.jenkins.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# configuration-as-code-groovy
+# Configuration as Code Plugin - Groovy Scripting Extension
+
 Extension for Jenkins Configuration-as-Code plugin that allows running Groovy scripts
 
 ## Run Groovy scripts

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     </properties>
     <name>Configuration as Code Plugin - Groovy Scripting Extension</name>
     <description>Plugin that extends JCasC with Groovy scripts execution</description>
+    <url>https://github.com/jenkinsci/configuration-as-code-groovy-plugin</url>
     <developers>
         <developer>
             <id>szandala</id>


### PR DESCRIPTION
Currently the documentation on plugins.jenkins.io is empty, let;s fix that. CC @casz @timja 
