### PR TITLE
Add secret variables expansion from CNode value

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, "2.107.1"], timeout: 180)
+buildPlugin(jenkinsVersions: [null], timeout: 180)

--- a/demos/variables-expansion.yml
+++ b/demos/variables-expansion.yml
@@ -1,0 +1,20 @@
+
+# Using jCasC secret expansion feature  
+# Secrets are loaded from :
+#  - Docker secrets
+#  - Kubernetes/Openshift secrets
+#  - HashiCorp Vault
+#  - Environment variables
+#
+# cf: https://github.com/jenkinsci/configuration-as-code-plugin/blob/master/docs/features/secrets.adoc
+
+groovy:
+
+  # Asuming secret value is stored in variable named API_KEY
+  - url: https://my.web.site.com/path/to/my/resource?api_key=${API_KEY}
+  # Same with basic auth example
+  - url: https://${USER}:${PASS}@my.web.site.com/path/to/my/resource
+
+  # Asuming secret value is stored in variable named SECRET
+  - script: >
+      println "Displaying my secret : ${SECRET}";

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <jenkins.version>2.222</jenkins.version>
         <java.level>8</java.level>
+        <configuration-as-code.version>1.42</configuration-as-code.version>
     </properties>
     <name>Configuration as Code Plugin - Groovy Scripting Extension</name>
     <description>Plugin that extends JCasC with Groovy scripts execution</description>
@@ -58,7 +59,12 @@
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>1.42</version>
+            <version>${configuration-as-code.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
+            <version>${configuration-as-code.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.18</version>
+        <version>4.12</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -12,10 +12,8 @@
     <version>1.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
+        <jenkins.version>2.222</jenkins.version>
         <java.level>8</java.level>
-        <useBeta>true</useBeta>
-        <access-modifier-checker.skip>true</access-modifier-checker.skip>
     </properties>
     <name>Configuration as Code Plugin - Groovy Scripting Extension</name>
     <description>Plugin that extends JCasC with Groovy scripts execution</description>
@@ -26,6 +24,10 @@
             <name>Tomasz Szandala</name>
             <email>tomasz.szandala@gmail.com</email>
         </developer>
+        <developer>
+            <id>jetersen</id>
+            <name>Joseph Petersen</name>
+        </developer>  
     </developers>
     <licenses>
         <license>
@@ -33,14 +35,12 @@
             <url>http://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
-    <!-- Assuming you want to host on @jenkinsci: -->
-    <!-- <url>http://wiki.jenkins.io/display/JENKINS/TODO+Plugin</url> -->
     <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
-      <tag>HEAD</tag>
-  </scm>
+        <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+        <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <repositories>
         <repository>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>1.32</version>
+            <version>1.42</version>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>1.0</version>
+            <version>1.32</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/io/jenkins/plugins/cascgroovy/GroovyScriptCaller.java
+++ b/src/main/java/io/jenkins/plugins/cascgroovy/GroovyScriptCaller.java
@@ -22,7 +22,7 @@ import static io.vavr.API.unchecked;
 /**
  * @author <a href="mailto:tomasz.szandala@gmail.com">Tomasz Szandala</a>
  */
-@Extension(optional = true, ordinal = -50)
+@Extension(optional = true, ordinal = -60) // Ordinal -60 Ensure it is loaded after JobDSL
 @Restricted(NoExternalUse.class)
 public class GroovyScriptCaller implements RootElementConfigurator<Boolean[]> {
 

--- a/src/main/java/io/jenkins/plugins/cascgroovy/GroovyScriptCaller.java
+++ b/src/main/java/io/jenkins/plugins/cascgroovy/GroovyScriptCaller.java
@@ -3,17 +3,24 @@ package io.jenkins.plugins.cascgroovy;
 import groovy.lang.Binding;
 import groovy.lang.GroovyShell;
 import hudson.Extension;
-import io.jenkins.plugins.casc.*;
+import io.jenkins.plugins.casc.Attribute;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.Configurator;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.RootElementConfigurator;
 import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
 import io.jenkins.plugins.casc.model.CNode;
 import io.jenkins.plugins.casc.model.Mapping;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
-import java.util.*;
 
 import static io.vavr.API.Try;
 import static io.vavr.API.unchecked;
@@ -27,6 +34,7 @@ import static io.vavr.API.unchecked;
 public class GroovyScriptCaller implements RootElementConfigurator<Boolean[]> {
 
     @Override
+    @Nonnull
     public String getName() {
         return "groovy";
     }
@@ -37,6 +45,7 @@ public class GroovyScriptCaller implements RootElementConfigurator<Boolean[]> {
     }
 
     @Override
+    @Nonnull
     public Set<Attribute<Boolean[],?>> describe() {
         return Collections.singleton(new MultivaluedAttribute("", GroovyScriptSource.class));
     }
@@ -47,13 +56,13 @@ public class GroovyScriptCaller implements RootElementConfigurator<Boolean[]> {
     }
 
     @Override
+    @Nonnull
     public Boolean[] configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
         final Configurator<GroovyScriptSource> c = context.lookup(GroovyScriptSource.class);
         return config.asSequence().stream()
             .map(source -> getActualValue(source, context))
-            .map(source -> Try(() -> c.configure(source, context).getScript())
-                                .onSuccess(GroovyScriptCaller.this::runGroovyShell)
-                                .isSuccess())
+            .map(source -> getScriptFromSource(source, context, c))
+            .map(script -> Try(script::getScript).onSuccess(GroovyScriptCaller.this::runGroovyShell).isSuccess())
             .toArray(Boolean[]::new);
     }
 
@@ -67,13 +76,21 @@ public class GroovyScriptCaller implements RootElementConfigurator<Boolean[]> {
         final Mapping m = new Mapping();
         m.put(
             entry.getKey(),
-            SecretSourceResolver.resolve(context, unchecked(() -> entry.getValue().asScalar().getValue()).apply())
+            context.getSecretSourceResolver().resolve(unchecked(() -> entry.getValue().asScalar().getValue()).apply())
         );
         return m;
     }
 
+    private GroovyScriptSource getScriptFromSource(CNode source, ConfigurationContext context,
+            Configurator<GroovyScriptSource> configurator) {
+        return unchecked(() ->
+                Try(() -> configurator.configure(source, context))
+                        .getOrElseThrow(t -> new ConfiguratorException(this,
+                                "Failed to retrieve groovy script", t))).apply();
+    }
+
     private void runGroovyShell(String script) {
-        final GroovyShell s = new GroovyShell(Jenkins.getActiveInstance().getPluginManager().uberClassLoader, new Binding());
+        final GroovyShell s = new GroovyShell(Jenkins.get().getPluginManager().uberClassLoader, new Binding());
         unchecked(() -> s.run(script, "ConfigurationAsCodeGroovy", new ArrayList()));
     }
 

--- a/src/main/java/io/jenkins/plugins/cascgroovy/GroovyScriptCaller.java
+++ b/src/main/java/io/jenkins/plugins/cascgroovy/GroovyScriptCaller.java
@@ -1,36 +1,28 @@
 package io.jenkins.plugins.cascgroovy;
 
-import jenkins.model.Jenkins;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import hudson.EnvVars;
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
 import hudson.Extension;
-import io.jenkins.plugins.casc.Attribute;
-import io.jenkins.plugins.casc.ConfigurationContext;
-import io.jenkins.plugins.casc.ConfiguratorException;
-import io.jenkins.plugins.casc.Configurator;
-import io.jenkins.plugins.casc.RootElementConfigurator;
+import io.jenkins.plugins.casc.*;
 import io.jenkins.plugins.casc.impl.attributes.MultivaluedAttribute;
 import io.jenkins.plugins.casc.model.CNode;
-import io.jenkins.plugins.casc.model.Sequence;
+import io.jenkins.plugins.casc.model.Mapping;
+import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
-import groovy.lang.GroovyShell;
-import groovy.lang.Binding;
 
-import java.io.PrintWriter;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+
+import static io.vavr.API.Try;
+import static io.vavr.API.unchecked;
 
 
 /**
  * @author <a href="mailto:tomasz.szandala@gmail.com">Tomasz Szandala</a>
  */
-@Extension(optional = true)
+@Extension(optional = true, ordinal = -50)
 @Restricted(NoExternalUse.class)
 public class GroovyScriptCaller implements RootElementConfigurator<Boolean[]> {
 
@@ -56,40 +48,35 @@ public class GroovyScriptCaller implements RootElementConfigurator<Boolean[]> {
 
     @Override
     public Boolean[] configure(CNode config, ConfigurationContext context) throws ConfiguratorException {
-        //JenkinsJobManagement mng = new JenkinsJobManagement(System.out, new EnvVars(), null, null, LookupStrategy.JENKINS_ROOT);
-        final Sequence sources = config.asSequence();
-        final Configurator<GroovyScriptSource> con = context.lookup(GroovyScriptSource.class);
-        List<Boolean> generated = new ArrayList<>();
-        for (CNode source : sources) {
-            final String script;
-            try {
-                script = con.configure(source, context).getScript();
-            } catch (IOException e) {
-                throw new ConfiguratorException(this, "Failed to retrieve Groovy script", e);
-            }
-            try {
-                //Binding binding = new Binding();
-                //binding.setVariable("foo", new Integer(2));
-                //GroovyShell shell = new GroovyShell();
-                //shell.evaluate(script);
-
-                Binding binding = new Binding();
-                //binding.setProperty("out",new PrintWriter(stdout,true));
-                //binding.setProperty("stdin",stdin);
-                //binding.setProperty("stdout",stdout);
-                //binding.setProperty("stderr",stderr);
-
-                GroovyShell groovy = new GroovyShell(Jenkins.getActiveInstance().getPluginManager().uberClassLoader, binding);
-                groovy.run(script, "Configuration-as-Code-Groovy", new ArrayList());
-
-                generated.add(true);
-
-            } catch (Exception ex) {
-                throw new ConfiguratorException(this, "Failed to execute script with hash " + script.hashCode(), ex);
-            }
-        }
-        return generated.toArray(new Boolean[generated.size()]);
+        final Configurator<GroovyScriptSource> c = context.lookup(GroovyScriptSource.class);
+        return config.asSequence().stream()
+            .map(source -> getActualValue(source, context))
+            .map(source -> Try(() -> c.configure(source, context).getScript())
+                                .onSuccess(GroovyScriptCaller.this::runGroovyShell)
+                                .isSuccess())
+            .toArray(Boolean[]::new);
     }
+
+    private CNode getActualValue(CNode source, ConfigurationContext context) {
+        return unchecked(() -> source.asMapping().entrySet().stream().findFirst()).apply()
+            .map(entry -> resolveSourceOrGetValue(entry, context))
+            .orElse(source);
+    }
+
+    private CNode resolveSourceOrGetValue(Map.Entry<String, CNode> entry, ConfigurationContext context) {
+        final Mapping m = new Mapping();
+        m.put(
+            entry.getKey(),
+            SecretSourceResolver.resolve(context, unchecked(() -> entry.getValue().asScalar().getValue()).apply())
+        );
+        return m;
+    }
+
+    private void runGroovyShell(String script) {
+        final GroovyShell s = new GroovyShell(Jenkins.getActiveInstance().getPluginManager().uberClassLoader, new Binding());
+        unchecked(() -> s.run(script, "Configuration-as-Code-Groovy", new ArrayList()));
+    }
+
 
     @Override
     public Boolean[] check(CNode config, ConfigurationContext context) throws ConfiguratorException {
@@ -99,7 +86,7 @@ public class GroovyScriptCaller implements RootElementConfigurator<Boolean[]> {
 
     @Nonnull
     @Override
-    public List<Configurator> getConfigurators(ConfigurationContext context) {
+    public List<Configurator<Boolean[]>> getConfigurators(ConfigurationContext context) {
         return Collections.singletonList(context.lookup(GroovyScriptSource.class));
     }
 
@@ -108,4 +95,5 @@ public class GroovyScriptCaller implements RootElementConfigurator<Boolean[]> {
     public CNode describe(Boolean[] instance, ConfigurationContext context) throws Exception {
         return null;
     }
+
 }

--- a/src/test/java/io/jenkins/plugins/cascgroovy/GroovyScriptTest.java
+++ b/src/test/java/io/jenkins/plugins/cascgroovy/GroovyScriptTest.java
@@ -1,0 +1,24 @@
+package io.jenkins.plugins.cascgroovy;
+
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import jenkins.model.Jenkins;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+public class GroovyScriptTest {
+    @Rule
+    public JenkinsConfiguredWithCodeRule j = new JenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("casc.yaml")
+    @Ignore
+    public void configure() throws Exception {
+        Jenkins jenkins = Jenkins.get();
+        assertThat(jenkins.getSystemMessage(), is("Hello World"));
+    }
+}

--- a/src/test/resources/io/jenkins/plugins/cascgroovy/casc.yaml
+++ b/src/test/resources/io/jenkins/plugins/cascgroovy/casc.yaml
@@ -1,0 +1,8 @@
+groovy:
+    - script: |
+        import jenkins.model.Jenkins;
+
+        def systemMessage = "Hello World";
+        def jenkins = Jenkins.get();
+        jenkins.setSystemMessage(systemMessage);
+        jenkins.save();


### PR DESCRIPTION
I faced jCasC secrets variables expansion issue with jCasC-Groovy plugin. 

So I made this PR to implement usage of jCasC secrets feature. 

As an example, this allows to setup secret token in URL to authenticate remote server.

Before, the following example wasn't working. 
```yaml
groovy:
  - url: http://login:${SECRET_TOKEN}@my.web.site/path/to/groovy/script.groovy
```

Regards