### PR TITLE
Groovy Script Caller: Class name without dashes

### DIFF
--- a/src/main/java/io/jenkins/plugins/cascgroovy/GroovyScriptCaller.java
+++ b/src/main/java/io/jenkins/plugins/cascgroovy/GroovyScriptCaller.java
@@ -80,7 +80,7 @@ public class GroovyScriptCaller implements RootElementConfigurator<Boolean[]> {
                 //binding.setProperty("stderr",stderr);
 
                 GroovyShell groovy = new GroovyShell(Jenkins.getActiveInstance().getPluginManager().uberClassLoader, binding);
-                groovy.run(script, "Configuration-as-Code-Groovy", new ArrayList());
+                groovy.run(script, "ConfigurationAsCodeGroovy", new ArrayList());
 
                 generated.add(true);
 


### PR DESCRIPTION
If a groovy script contains a function definition, e.g.:

```
def hash(x String) {
   return x
}

hash("foo")
```

CasC will fail to reload with, e.g.:

```
java.lang.ClassFormatError: Illegal class name "Configuration-as-Code-Groovy$hash" in class file Configuration-as-Code-Groovy$hash
```