### PR TITLE
Remove version from configuration-as-code dependency

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,7 @@
-buildPlugin(jenkinsVersions: [null, "2.249.2"], timeout: 180)
+buildPlugin(
+  forkCount: '1C',
+  useContainerAgent: true,
+  configurations: [
+    [platform: 'linux', jdk: 21],
+    [platform: 'windows', jdk: 17],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.18</version>
+        <version>4.64</version>
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
@@ -12,8 +12,7 @@
     <version>1.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.60.3</jenkins.version>
-        <java.level>8</java.level>
+        <jenkins.version>2.414.3</jenkins.version>
         <useBeta>true</useBeta>
         <access-modifier-checker.skip>true</access-modifier-checker.skip>
     </properties>
@@ -54,11 +53,21 @@
             <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2643.vfa_93ff299d20</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>1.0</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/io/jenkins/plugins/cascgroovy/GroovyScriptCaller.java
+++ b/src/main/java/io/jenkins/plugins/cascgroovy/GroovyScriptCaller.java
@@ -99,7 +99,7 @@ public class GroovyScriptCaller implements RootElementConfigurator<Boolean[]> {
 
     @Nonnull
     @Override
-    public List<Configurator> getConfigurators(ConfigurationContext context) {
+    public List<Configurator<Boolean[]>> getConfigurators(ConfigurationContext context) {
         return Collections.singletonList(context.lookup(GroovyScriptSource.class));
     }
 


### PR DESCRIPTION
The plugin did not work with latest releases of configuration-as-code because it pinned to version 1.0.